### PR TITLE
Update Render_Multiple_Write_Nodes_v07.py

### DIFF
--- a/Render_Multiple_Write_Nodes_v07.py
+++ b/Render_Multiple_Write_Nodes_v07.py
@@ -1,13 +1,14 @@
 import nuke
+render_information = []
+def showChannels():
+    global render_information
+    return '\n'.join(render_information)
+
 def RenderMultipleNodes():
+    global render_information
     render_information = []
-    
-    def showChannels():
-        return '\n'.join(render_information)
-    
-    
+
     node = nuke.toNode('Write1') #Just for avoiding error. It will not use while running the code
-    
     
     for i in nuke.selectedNodes():
         


### PR DESCRIPTION
use render_information as global to be able to get data from anywhere
and move showChannels function out of RenderMultipleNodes